### PR TITLE
wrong stack trace

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,8 +78,7 @@ var Session = exports.Session = function (id, wrapper) {
             return;
         }
         
-        try { self.handle(msg) }
-        catch (err) { self.emit('error', err) }
+        self.handle(msg);
     };
     
     self.handle = function (req) {
@@ -140,8 +139,7 @@ var Session = exports.Session = function (id, wrapper) {
     }
     
     function apply(f, obj, args) {
-        try { f.apply(obj, args) }
-        catch (err) { self.emit('error', err) }
+        f.apply(obj, args);
     }
     
     return self;


### PR DESCRIPTION
Hi —

Working with dnode, I commonly run into an error where I get the "wrong" stack trace.  I can reproduce it pretty easily, by editing one of the examples in the repo.

```javascript
    window.onload = function () {
        DNode.connect(function (remote) {
            remote.cat(function (says) {
                throw 42;
            });
        });
    };
```

In the console, instead of seeing a useful stack trace, I see:

Error: Uncaught, unspecified 'error' event.  (http://d.pr/MchA)  Worse, the line number is wrong.  (meaning, it is not the line that's responsible for throwing the error.)

This can be annoying, especially when one is working on a project that's less trivial, because one has no idea what line number actually threw the error.

Poking around, I found out that the two try/catch statements in dnode-protocol we actually responsible for masking the line number for the error.  My instinct tells me that those try/catch are there for a good reason, but (at least during active development), I want to know where my errors are coming from.