### PR TITLE
Encapsulate callbacks in Scrubber, use non-sequential callback ids and store callbacks in a map to increase performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+*.iml

--- a/index.js
+++ b/index.js
@@ -20,11 +20,11 @@ function Proto (cons, opts) {
     if (!opts) opts = {};
     
     self.remote = {};
-    self.callbacks = { local : [], remote : [] };
+    self.callbacks = { remote : [] };
     self.wrap = opts.wrap;
     self.unwrap = opts.unwrap;
     
-    self.scrubber = scrubber(self.callbacks.local);
+    self.scrubber = scrubber();
     
     if (typeof cons === 'function') {
         self.instance = new cons(self.remote, self);
@@ -77,9 +77,7 @@ Proto.prototype.handle = function (req) {
         self.handleMethods(args[0]);
     }
     else if (req.method === 'cull') {
-        forEach(args, function (id) {
-            delete self.callbacks.local[id];
-        });
+        forEach(args, this.scrubber.cull.bind(this.scrubber));
     }
     else if (typeof req.method === 'string') {
         if (isEnumerable(self.instance, req.method)) {
@@ -92,7 +90,7 @@ Proto.prototype.handle = function (req) {
         }
     }
     else if (typeof req.method == 'number') {
-        var fn = self.callbacks.local[req.method];
+        var fn = self.scrubber.find(req.method);
         if (!fn) {
             self.emit('fail', new Error('no such method'));
         }

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function Proto (cons, opts) {
     if (!opts) opts = {};
     
     self.remote = {};
-    self.callbacks = { remote : [] };
+    self.callbacks = { remote : {} };
     self.wrap = opts.wrap;
     self.unwrap = opts.unwrap;
     
@@ -79,22 +79,17 @@ Proto.prototype.handle = function (req) {
     else if (req.method === 'cull') {
         forEach(args, this.scrubber.cull.bind(this.scrubber));
     }
-    else if (typeof req.method === 'string') {
-        if (isEnumerable(self.instance, req.method)) {
+    else {
+        var fn = self.scrubber.find(req.method);
+        if (fn) {
+            self.apply(fn, args);
+        }
+        else if (isEnumerable(self.instance, req.method)) {
             self.apply(self.instance[req.method], args);
         }
         else {
-            self.emit('fail', new Error(
-                'request for non-enumerable method: ' + req.method
-            ));
-        }
-    }
-    else if (typeof req.method == 'number') {
-        var fn = self.scrubber.find(req.method);
-        if (!fn) {
             self.emit('fail', new Error('no such method'));
         }
-        else self.apply(fn, args);
     }
 };
 

--- a/lib/scrub.js
+++ b/lib/scrub.js
@@ -9,13 +9,13 @@ function indexOf (xs, x) {
 }
 
 // scrub callbacks out of requests in order to call them again later
-module.exports = function (callbacks) {
-    return new Scrubber(callbacks);
+module.exports = function () {
+    return new Scrubber();
 };
 
-function Scrubber (callbacks) {
-    this.callbacks = callbacks;
-}
+function Scrubber () {
+    this.callbacks = [];
+};
 
 // Take the functions out and note them for future use
 Scrubber.prototype.scrub = function (obj) {
@@ -69,4 +69,12 @@ Scrubber.prototype.unscrub = function (msg, f) {
     });
     
     return args;
+};
+
+Scrubber.prototype.cull = function (id) {
+  delete this.callbacks[id]
+};
+
+Scrubber.prototype.find = function (id) {
+  return this.callbacks[id]
 };

--- a/lib/scrub.js
+++ b/lib/scrub.js
@@ -3,14 +3,6 @@ var objectKeys = require('./keys');
 var forEach = require('./foreach');
 var shortId = require('shortid');
 
-function indexOf (xs, x) {
-    for(var key in xs) {
-      if(xs[key] == x) {
-        return key
-      }
-    }
-}
-
 // scrub callbacks out of requests in order to call them again later
 module.exports = function () {
     return new Scrubber();
@@ -25,10 +17,11 @@ Scrubber.prototype.scrub = function (obj) {
     var self = this;
     var paths = {};
     var links = [];
+    var found = {};
     
     var args = traverse(obj).map(function (node) {
         if (typeof node === 'function') {
-            var id = indexOf(self.callbacks, node);
+            var id = found[node];
             if (id && !(id in paths)) {
                 // Keep previous function IDs only for the first function
                 // found. This is somewhat suboptimal but the alternatives
@@ -37,6 +30,7 @@ Scrubber.prototype.scrub = function (obj) {
             }
             else {
                 id = shortId.generate();
+                found[node] = id;
                 self.callbacks[id] = node;
                 paths[id] = this.path;
             }

--- a/lib/scrub.js
+++ b/lib/scrub.js
@@ -1,11 +1,14 @@
 var traverse = require('traverse');
 var objectKeys = require('./keys');
 var forEach = require('./foreach');
+var shortId = require('shortid');
 
 function indexOf (xs, x) {
-    if (xs.indexOf) return xs.indexOf(x);
-    for (var i = 0; i < xs.length; i++) if (xs[i] === x) return i;
-    return -1;
+    for(var key in xs) {
+      if(xs[key] == x) {
+        return key
+      }
+    }
 }
 
 // scrub callbacks out of requests in order to call them again later
@@ -14,7 +17,7 @@ module.exports = function () {
 };
 
 function Scrubber () {
-    this.callbacks = [];
+    this.callbacks = {};
 };
 
 // Take the functions out and note them for future use
@@ -25,16 +28,16 @@ Scrubber.prototype.scrub = function (obj) {
     
     var args = traverse(obj).map(function (node) {
         if (typeof node === 'function') {
-            var i = indexOf(self.callbacks, node);
-            if (i >= 0 && !(i in paths)) {
+            var id = indexOf(self.callbacks, node);
+            if (id && !(id in paths)) {
                 // Keep previous function IDs only for the first function
                 // found. This is somewhat suboptimal but the alternatives
                 // are worse.
-                paths[i] = this.path;
+                paths[id] = this.path;
             }
             else {
-                var id = self.callbacks.length;
-                self.callbacks.push(node);
+                id = shortId.generate();
+                self.callbacks[id] = node;
                 paths[id] = this.path;
             }
             
@@ -57,8 +60,7 @@ Scrubber.prototype.scrub = function (obj) {
 // return a callback of its own.
 Scrubber.prototype.unscrub = function (msg, f) {
     var args = msg.arguments || [];
-    forEach(objectKeys(msg.callbacks || {}), function (sid) {
-        var id = parseInt(sid, 10);
+    Object.keys(msg.callbacks || {}).forEach(function (id) {
         var path = msg.callbacks[id];
         traverse.set(args, path, f(id));
     });

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "main": "./index.js",
     "dependencies" : {
         "traverse" : "~0.6.3",
-        "jsonify" : "~0.0.0"
+        "jsonify" : "~0.0.0",
+        "shortid": "~2.1.3"
     },
     "devDependencies" : {
         "tap" : "~0.3.3",

--- a/test/fn.js
+++ b/test/fn.js
@@ -5,7 +5,7 @@ var traverse = require('traverse');
 var EventEmitter = require('events').EventEmitter;
 
 test('protoFn', function (t) {
-    t.plan(7);
+    t.plan(10);
     
     var s = proto(function (remote, conn) {
         t.ok(conn);
@@ -37,10 +37,11 @@ test('protoFn', function (t) {
     
     s.start();
     
+    t.deepEqual(sreqs[0].callbacks[Object.keys(sreqs[0].callbacks)[0]], [ '0', 'x' ]);
     t.deepEqual(sreqs, [ {
         method : 'methods',
         arguments : [ { x : '[Function]', y : 555 } ],
-        callbacks : { 0 : [ '0', 'x' ] },
+        callbacks : sreqs[0].callbacks,
         links : []
     } ]);
     
@@ -65,10 +66,12 @@ test('protoFn', function (t) {
         }
     ]);
     
+    t.deepEqual(creqs.slice(1)[0].callbacks[Object.keys(creqs.slice(1)[0].callbacks)[0]], [ '0' ]);
+    t.deepEqual(creqs.slice(1)[0].callbacks[Object.keys(creqs.slice(1)[0].callbacks)[1]], [ '1' ]);
     t.deepEqual(creqs.slice(1), [ {
         method : 'x',
         arguments : [ '[Function]', '[Function]' ],
-        callbacks : { 0 : [ '0' ], 1 : [ '1' ] },
+        callbacks : creqs.slice(1)[0].callbacks,
         links : []
     } ]);
 });

--- a/test/proto.js
+++ b/test/proto.js
@@ -3,7 +3,7 @@ var proto = require('../');
 var traverse = require('traverse');
 
 test('proto hashes', function (t) {
-    t.plan(5);
+    t.plan(8);
     
     var s = proto({
         x : function (f, g) {
@@ -29,10 +29,11 @@ test('proto hashes', function (t) {
     
     s.start();
     
+    t.deepEqual(sreqs[0].callbacks[Object.keys(sreqs[0].callbacks)[0]], [ '0', 'x' ]);
     t.deepEqual(sreqs, [ {
         method : 'methods',
         arguments : [ { x : '[Function]', y : 555 } ],
-        callbacks : { 0 : [ '0', 'x' ] },
+        callbacks : sreqs[0].callbacks,
         links : []
     } ]);
     
@@ -55,10 +56,12 @@ test('proto hashes', function (t) {
         }
     ]);
     
+    t.deepEqual(creqs.slice(1)[0].callbacks[Object.keys(creqs.slice(1)[0].callbacks)[0]], [ '0' ]);
+    t.deepEqual(creqs.slice(1)[0].callbacks[Object.keys(creqs.slice(1)[0].callbacks)[1]], [ '1' ]);
     t.deepEqual(creqs.slice(1), [ {
         method : 'x',
         arguments : [ '[Function]', '[Function]' ],
-        callbacks : { 0 : [ '0' ], 1 : [ '1' ] },
+        callbacks : creqs.slice(1)[0].callbacks,
         links : []
     } ]);
 });

--- a/test/scrub.js
+++ b/test/scrub.js
@@ -31,16 +31,20 @@ test('functions', function (t) {
     var g = function () { calls.g ++ };
     
     var sc = s.scrub([ 1, 2, f, g ]);
+    var ids = Object.keys(sc.callbacks)
+    
+    t.deepEqual(sc.callbacks[ids[0]], [ '2' ]);
+    t.deepEqual(sc.callbacks[ids[1]], [ '3' ]);
     t.deepEqual(sc, {
         arguments : [ 1, 2, '[Function]', '[Function]' ],
-        callbacks : { 0 : [ '2' ], 1 : [ '3' ] },
+        callbacks : sc.callbacks,
         links : []
     });
     
-    s.callbacks[0]();
+    s.callbacks[ids[0]]();
     t.deepEqual(calls, { f : 1, g : 0 });
     
-    s.callbacks[1]();
+    s.callbacks[ids[1]]();
     t.deepEqual(calls, { f : 1, g : 1 });
     
     t.end();

--- a/test/wrap.js
+++ b/test/wrap.js
@@ -3,7 +3,7 @@ var proto = require('../');
 var traverse = require('traverse');
 
 test('proto hashes', function (t) {
-    t.plan(10);
+    t.plan(13);
     var pending = 5;
     
     var times = { s : 0, c : 0 };
@@ -53,10 +53,11 @@ test('proto hashes', function (t) {
     
     s.start();
     
+    t.deepEqual(sreqs[0].callbacks[Object.keys(sreqs[0].callbacks)[0]], [ '0', 'x' ]);
     t.deepEqual(sreqs, [ {
         method : 'methods',
         arguments : [ { x : '[Function]', y : 555 } ],
-        callbacks : { 0 : [ '0', 'x' ] },
+        callbacks : sreqs[0].callbacks,
         links : []
     } ]);
     
@@ -80,10 +81,12 @@ test('proto hashes', function (t) {
         }
     ]);
     
+    t.deepEqual(creqs.slice(1)[0].callbacks[Object.keys(creqs.slice(1)[0].callbacks)[0]], [ '0' ]);
+    t.deepEqual(creqs.slice(1)[0].callbacks[Object.keys(creqs.slice(1)[0].callbacks)[1]], [ '1' ]);
     t.deepEqual(creqs.slice(1), [ {
         method : 'x',
         arguments : [ '[Function]', '[Function]' ],
-        callbacks : { 0 : [ '0' ], 1 : [ '1' ] },
+        callbacks : creqs.slice(1)[0].callbacks,
         links : []
     } ]);
 });


### PR DESCRIPTION
This pull request does ~~three~~ four things (sorry):

1. Adds a .gitignore file
2. Currently the list of local callbacks is shared between the Proto and Scrubber classes with one adding things to the list and the other removing them. I've changed it so that the Scrubber maintains the list and doesn't share it with Proto any more for better data encapsulation.
3. Changes the list of local callbacks to a map - this also means that callback ids are now non-sequential.
4. Apply the changes from #15 to further increase performance.

See the graph below for the performance differences.  The test running is substack/dnode#159

The blue line is the performance of the current master, the red line is after (3) has been applied, the green line is after (3) and (4) have been applied.

Each test was run for an hour and then the data points averaged to reduce the effect of outliers.

E.g. On my machine the average RTT of the current master is about 0.63ms, (3) drops it to 0.46ms and (4) to 0.37ms.  All these times are good, tbh, dnode is not slow..

![dnode-perf](https://cloud.githubusercontent.com/assets/665810/5822249/b4763e1a-a0d2-11e4-806e-9d515919e083.jpg)